### PR TITLE
Fix inferspect package installation error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Automation scripts supporting the InferSpect workflows"
 authors = ["InferSpect Maintainers <opensource@inferspect.dev>"]
 readme = "README.md"
+packages = [
+    { include = "inferspect", from = "src" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/src/inferspect/__init__.py
+++ b/src/inferspect/__init__.py
@@ -1,0 +1,18 @@
+"""InferSpect automation helpers exposed as a Python package."""
+
+from __future__ import annotations
+
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+
+__all__ = ("get_package_version",)
+
+
+def get_package_version() -> str:
+    """Return the installed InferSpect distribution version."""
+    try:
+        return metadata.version("inferspect")
+    except PackageNotFoundError as exc:
+        raise RuntimeError(
+            "InferSpect package metadata not found. Install via `poetry install`."
+        ) from exc


### PR DESCRIPTION
Configure Poetry to correctly install the `inferspect` project by adopting a `src/` layout and defining the package location.

The CI workflow's `poetry install` step was failing because the `inferspect` package was not discoverable or installable by Poetry, resulting in a "No file/folder found for package inferspect" error. This change explicitly tells Poetry where to find the package's source.

---
<a href="https://cursor.com/background-agent?bcId=bc-3640852d-f45b-4c08-91fa-074a39bda131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3640852d-f45b-4c08-91fa-074a39bda131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

